### PR TITLE
fix: normalize filepath on windows

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import Less from 'less'
 import path from 'path'
+import { normalizePath } from './utils'
 
 // ref: less-plugin-module-resolver
 // https://github.com/bundle-matters/less-plugin-module-resolver/blob/main/src/alias-file-manager.ts
@@ -7,24 +8,24 @@ import path from 'path'
 export class LessPluginRemoveAntdGlobalStyles implements Less.Plugin {
   constructor() {}
 
-  public install(less: LessStatic, pluginManager: Less.PluginManager): void {
-    pluginManager.addFileManager(new AliasFileManager())
+  public install(_less: LessStatic, pluginManager: Less.PluginManager): void {
+    pluginManager.addFileManager(new FileManager())
   }
 }
 
-class AliasFileManager extends Less.FileManager {
+class FileManager extends Less.FileManager {
   constructor() {
     super()
   }
   public supports(
     filename: string,
     currentDirectory: string,
-    options: Less.LoadFileOptions,
-    environment: Less.Environment
+    _options: Less.LoadFileOptions,
+    _environment: Less.Environment
   ): boolean {
     if (filename.includes('global')) {
       // match antd global style file
-      const fullPath = path.join(currentDirectory, filename)
+      const fullPath = normalizePath(path.join(currentDirectory, filename))
       if (
         fullPath.includes('antd/es/style/core/global') ||
         fullPath.includes('antd/lib/style/core/global')
@@ -35,12 +36,7 @@ class AliasFileManager extends Less.FileManager {
     return false
   }
 
-  public async loadFile(
-    filename: string,
-    currentDirectory: string,
-    options: Less.LoadFileOptions,
-    environment: Less.Environment
-  ): Promise<Less.FileLoadResult> {
+  public async loadFile(): Promise<Less.FileLoadResult> {
     return {
       filename: 'dummy-empty-global-style.less',
       contents: '',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,12 @@
+import path from 'path'
+import os from 'os'
+
+export const isWindows = os.platform() === 'win32'
+
+export function slash(p: string): string {
+  return p.replace(/\\/g, '/')
+}
+
+export function normalizePath(id: string): string {
+  return path.posix.normalize(isWindows ? slash(id) : id)
+}


### PR DESCRIPTION
`const fullPath = path.join(currentDirectory, filename)`

this code will give out a path like: `C:\someone\path` which will not match `/`.